### PR TITLE
use 127.0.0.1 to access localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ everytime you start Omega it will just ask for the decryption key:
 
 (The idea is that you might not be able to remember your openAI key by heart, but you might be able to do so with your own password or passphrase)
 
-You can then direct your browser to: [http://0.0.0.0:9000/](http://0.0.0.0:9000/)
+You can then direct your browser to: [http://127.0.0.1:9000/](http://127.0.0.1:9000/)
 and start having an hopefully nice chat with Omega.
 
 

--- a/src/napari_chatgpt/chat_server/chat_server.py
+++ b/src/napari_chatgpt/chat_server/chat_server.py
@@ -147,7 +147,7 @@ class NapariChatServer:
 
     def run(self):
         import uvicorn
-        uvicorn.run(self.app, host="0.0.0.0", port=9000)
+        uvicorn.run(self.app, host="127.0.0.1", port=9000)
 
 
 def start_chat_server(viewer: napari.Viewer = None):
@@ -175,7 +175,7 @@ def start_chat_server(viewer: napari.Viewer = None):
 
     # function to open browser on page:
     def _open_browser():
-        url = "http://0.0.0.0:9000"
+        url = "http://127.0.0.1:9000"
         webbrowser.open(url, new=0, autoraise=True)
 
     # open browser after delay of a few seconds:


### PR DESCRIPTION
Hi @royerloic ,

this makes Omega work on my Windows. 127.0.0.1 is commonly used to connect to [localhost](https://en.wikipedia.org/wiki/Localhost), [0.0.0.0](https://en.wikipedia.org/wiki/0.0.0.0) can have multiple purposes and I have never seen it in the wild. If 127.0.0.1 works on your Mac too, it would be great to merge this.

closes #1 

Cheers,
Robert