### PR TITLE
run napari only from main

### DIFF
--- a/src/napari_chatgpt/chat_server/chat_server.py
+++ b/src/napari_chatgpt/chat_server/chat_server.py
@@ -181,9 +181,11 @@ def start_chat_server(viewer: napari.Viewer = None):
     # open browser after delay of a few seconds:
     QTimer.singleShot(2000, _open_browser)
 
-    # Start qt event loop and wait for it to stop:
-    napari.run()
+
 
 
 if __name__ == "__main__":
     start_chat_server()
+
+    # Start qt event loop and wait for it to stop:
+    napari.run()


### PR DESCRIPTION
When starting Omega from the menu, I received this warning message:

![image](https://user-images.githubusercontent.com/12660498/236640926-e5747ce1-b712-481e-afdf-41e787bf35ef.png)

It goes away when merging this PR. Reason: `napari.run()` must not be executed when napari is already running.