### PR TITLE
adding support for azure, cohere, replicate and unifying claude/openai call

### DIFF
--- a/src/napari_chatgpt/llm/llms.py
+++ b/src/napari_chatgpt/llm/llms.py
@@ -4,7 +4,8 @@ import os
 from arbol import aprint
 from langchain.callbacks.manager import AsyncCallbackManager
 from langchain.chat_models import ChatOpenAI, ChatAnthropic
-
+import litellm
+from litellm import completion
 from napari_chatgpt.llm.bard import ChatBard
 from napari_chatgpt.llm.gpt4all import GPT4AllFixed
 from napari_chatgpt.utils.download.gpt4all import get_gpt4all_model
@@ -19,13 +20,14 @@ def instantiate_LLMs(llm_model_name: str,
                      verbose: bool = False
                      ):
     aprint(f"Instantiating LLMs with model: '{llm_model_name}', t={temperature}, t_tool={tool_temperature}. ")
-    if 'gpt-' in llm_model_name:
+    if 'gpt-' in llm_model_name or "claude" in llm_model_name:
         # Instantiates Main LLM:
         main_llm = ChatOpenAI(
             model_name=llm_model_name,
             verbose=verbose,
             streaming=True,
             temperature=temperature,
+            client = completion,
             callback_manager=AsyncCallbackManager(
                 [chat_callback_handler])
         )
@@ -36,7 +38,7 @@ def instantiate_LLMs(llm_model_name: str,
             verbose=verbose,
             streaming=True,
             temperature=tool_temperature,
-
+            client = completion,
             callback_manager=AsyncCallbackManager([tool_callback_handler])
         )
 
@@ -45,6 +47,7 @@ def instantiate_LLMs(llm_model_name: str,
             model_name=llm_model_name,
             verbose=False,
             temperature=temperature,
+            client = completion,
             callback_manager=AsyncCallbackManager([memory_callback_handler])
         )
 
@@ -76,40 +79,6 @@ def instantiate_LLMs(llm_model_name: str,
         )
 
         max_token_limit = 1000
-
-    elif 'claude' in llm_model_name:
-
-        # Instantiates Main LLM:
-        main_llm = ChatAnthropic(
-            model=llm_model_name,
-            verbose=verbose,
-            streaming=True,
-            temperature=temperature,
-            max_tokens_to_sample=4096,
-            callback_manager=AsyncCallbackManager(
-                [chat_callback_handler])
-        )
-
-        # Instantiates Tool LLM:
-        tool_llm = ChatAnthropic(
-            model=llm_model_name,
-            verbose=verbose,
-            streaming=True,
-            temperature=tool_temperature,
-            max_tokens_to_sample=4096,
-            callback_manager=AsyncCallbackManager([tool_callback_handler])
-        )
-
-        # Instantiates Memory LLM:
-        memory_llm = ChatAnthropic(
-            model=llm_model_name,
-            verbose=False,
-            temperature=temperature,
-            max_tokens_to_sample=4096,
-            callback_manager=AsyncCallbackManager([memory_callback_handler])
-        )
-
-        max_token_limit = 8000
 
     elif 'ggml' in llm_model_name:
 


### PR DESCRIPTION
Hi @royerloic,

Noticed you're calling multiple providers w/ langchain. I'm working on litellm (simple library to standardize LLM API Calls - https://github.com/BerriAI/litellm) and was wondering if we could be helpful.

I unified your claude + openai call and added support for Cohere, Azure and Llama2 (via Replicate) by setting client in the langchain ChatOpenAI class. The code is pretty similar to the OpenAI class - as litellm follows the same pattern as the openai-python sdk.

Would love to know if this helps.

Happy to add additional tests / update documentation, if the initial PR looks good to you.