### PR TITLE
bugfix: openai models not discoverable

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,7 @@ install_requires =
     nbformat
     jedi
     black
+    httpx==0.27.2
 
     # needed because lxml has spun out this code out of its main repo:
     lxml_html_clean


### PR DESCRIPTION
Hi @royerloic ,

a student of mine reported that openai models are not discoverable by napari-chatgpt, with an error message in the terminal. I found the error [online](https://community.openai.com/t/error-with-openai-1-56-0-client-init-got-an-unexpected-keyword-argument-proxies/1040332/3), tested the proposed solution of downgrading [httpx](https://www.python-httpx.org/) to 0.27.2 and it worked. Hence, you find this solution here as PR.

closes #62

Best,
Robert


Full error message:
```
|\ Enumerating all OpenAI ChatGPT models:
||\ Setting API key: 'OpenAI':
|||-> API key name: 'OPENAI_API_KEY'
|||-> API key is already set as an environment variable!
||-<< 0.00 microseconds
||
||-> Error: TypeError with message: 'Client.__init__() got an unexpected keyword argument 'proxies'' occured while trying to get the list of OpenAI models.
Traceback (most recent call last):
  File "C:\Users\rober\miniforge3\envs\nap-gpt\Lib\site-packages\napari_chatgpt\utils\openai\model_list.py", line 39, in get_openai_model_list
    client = OpenAI()
             ^^^^^^^^
  File "C:\Users\rober\miniforge3\envs\nap-gpt\Lib\site-packages\openai\_client.py", line 123, in __init__
    super().__init__(
  File "C:\Users\rober\miniforge3\envs\nap-gpt\Lib\site-packages\openai\_base_client.py", line 844, in __init__
    self._client = http_client or SyncHttpxClientWrapper(
                                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rober\miniforge3\envs\nap-gpt\Lib\site-packages\openai\_base_client.py", line 742, in __init__
    super().__init__(**kwargs)
TypeError: Client.__init__() got an unexpected keyword argument 'proxies'
|-<< 1.42 milliseconds
|
|-> Setting up model selection UI.
|\ Enumerating all OpenAI ChatGPT models:
||\ Setting API key: 'OpenAI':
|||-> API key name: 'OPENAI_API_KEY'
|||-> API key is already set as an environment variable!
||-<< 0.00 microseconds
||
||-> Error: TypeError with message: 'Client.__init__() got an unexpected keyword argument 'proxies'' occured while trying to get the list of OpenAI models.
Traceback (most recent call last):
  File "C:\Users\rober\miniforge3\envs\nap-gpt\Lib\site-packages\napari_chatgpt\utils\openai\model_list.py", line 39, in get_openai_model_list
    client = OpenAI()
             ^^^^^^^^
  File "C:\Users\rober\miniforge3\envs\nap-gpt\Lib\site-packages\openai\_client.py", line 123, in __init__
    super().__init__(
  File "C:\Users\rober\miniforge3\envs\nap-gpt\Lib\site-packages\openai\_base_client.py", line 844, in __init__
    self._client = http_client or SyncHttpxClientWrapper(
                                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rober\miniforge3\envs\nap-gpt\Lib\site-packages\openai\_base_client.py", line 742, in __init__
    super().__init__(**kwargs)
TypeError: Client.__init__() got an unexpected keyword argument 'proxies'
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
	- Added `httpx` library version 0.27.2 as a project dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->